### PR TITLE
refactor : 테마파크 목록 페이지 불러오기 및 시설 더보기 버튼 클릭시 시설 목록 출력

### DIFF
--- a/src/examples/Sidenav/index.vue
+++ b/src/examples/Sidenav/index.vue
@@ -30,7 +30,7 @@ const darkMode = computed(() => store.state.layout.darkMode);
     id="sidenav-main"
   >
     <div class="sidenav-header">
-      <router-link class="m-0 navbar-brand" to="/">
+      <router-link class="m-0 navbar-brand" to="/dashboard-default">
         <img
           :src="darkMode || sidebarType === 'bg-default' ? logoWhite : logo"
           class="navbar-brand-img"

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,6 +7,7 @@ import dining from "./modules/dining";
 import service from "./modules/service";
 import theme from "./modules/theme";
 import suggestion from "./modules/suggestion";
+import pay from "./modules/pay";
 
 export default createStore({
   modules: {
@@ -37,6 +38,10 @@ export default createStore({
     suggestion: {
       namespaced: true,
       ...suggestion,
+    },
+    pay: {
+      namespaced: true,
+      ...pay,
     },
   },
 });

--- a/src/store/modules/pay.js
+++ b/src/store/modules/pay.js
@@ -1,0 +1,67 @@
+import apiClient from "@/api";
+// import image from "../../assets/img/002.png";
+
+export default {
+  namespaced: true,
+  state: {
+    isAuthenticated: true, // 초기 상태를 true로 설정 (필요에 따라 조정)
+    suggestions: [], // 공지사항 리스트를 저장할 상태
+
+    suggestionId: null,
+  },
+  mutations: {
+    setsuggestions(state, suggestions) {
+      console.log("받아온 건의사항 데이터 : ", suggestions);
+      state.suggestions = suggestions;
+    },
+    setAuthState(state, status) {
+      state.isAuthenticated = status;
+    },
+    setSuggestionId(state, id) {
+      state.suggestionId = id;
+    },
+  },
+  actions: {
+    async getAllSuggestions({ commit }) {
+      try {
+        const response = await apiClient.get(`/suggestions`);
+        console.log("응답 : ", response);
+        console.log("응답 데이터 : ", response.data);
+
+        const suggestionsData = response.data.map((suggestions) => ({
+          id: suggestions.id,
+          title: suggestions.title,
+          author: suggestions.email, // accommodationName을 location으로
+          submittedDate: suggestions.subject, // description을 openingDate로 사용
+        }));
+        console.log("받아온 건의사항 데이터:", suggestionsData);
+        commit("setsuggestions", suggestionsData); // 상태 업데이트
+      } catch (error) {
+        console.error("건의사항 목록 가져오기 실패:", error);
+      }
+    },
+    async reply(context, replyContent) {
+      try {
+        const response = await apiClient.post("/suggestions/reply", {
+          suggestionId: context.state.suggestionId,
+          replyContent,
+        });
+        console.log("응답 제출 : ", response);
+      } catch (error) {
+        console.log("답변 제출 실패 : ", error);
+      }
+    },
+
+    // 로그아웃 액션
+    logout({ commit }) {
+      // 토큰 제거
+      localStorage.removeItem("accessToken");
+      localStorage.removeItem("refreshToken");
+      commit("clearAuthState"); // 인증 상태 초기화
+    },
+  },
+  getters: {
+    isAuthenticated: (state) => state.isAuthenticated, // 인증 여부 확인
+    currentUser: (state) => state.user, // 현재 유저 정보 반환
+  },
+};

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -135,7 +135,7 @@ const sales = {
           </div>
           <div class="col-lg-5">
             <!-- 그림들 (노을 풍경, 리조트 풍경 등) -->
-            <carousel />
+            <Carousel />
           </div>
         </div>
         <div class="row mt-4">

--- a/src/views/components/Carousel.vue
+++ b/src/views/components/Carousel.vue
@@ -2,7 +2,7 @@
   <div class="card card-carousel overflow-hidden h-100 p-0">
     <div
       id="carouselExampleCaptions"
-      class="carousel slide h-200"
+      class="carousel slide h-100"
       data-bs-ride="carousel"
     >
       <div class="carousel-inner border-radius-lg h-100">
@@ -23,10 +23,6 @@
               <i class="ni ni-camera-compact text-dark opacity-10"></i>
             </div>
             <h5 class="text-white mb-1">노을 풍경</h5>
-            <!-- <p>
-              There’s nothing I really wanted to do in life that I wasn’t able
-              to get good at.
-            </p> -->
           </div>
         </div>
         <div

--- a/src/views/components/ThemeParksTable.vue
+++ b/src/views/components/ThemeParksTable.vue
@@ -79,6 +79,8 @@
               <div class="facility-info">
                 <h6 class="facility-name">{{ facility.name }}</h6>
                 <p class="facility-description">{{ facility.introduction }}</p>
+                <p class="facility-description">{{ facility.information }}</p>
+                <p class="facility-description">{{ facility.standardUse }}</p>
               </div>
             </div>
           </div>

--- a/src/views/components/ThemeParksTable.vue
+++ b/src/views/components/ThemeParksTable.vue
@@ -72,13 +72,13 @@
               class="facility-card"
             >
               <img
-                :src="facility.imageUrls[0]"
+                :src="facility.imageUrl"
                 alt="시설 이미지"
                 class="facility-image"
               />
               <div class="facility-info">
                 <h6 class="facility-name">{{ facility.name }}</h6>
-                <p class="facility-description">{{ facility.description }}</p>
+                <p class="facility-description">{{ facility.introduction }}</p>
               </div>
             </div>
           </div>
@@ -109,6 +109,7 @@ export default {
         );
         const data = await response.json();
         this.selectedParkFacilities = data.data; // 데이터 바인딩
+        console.log("이것이 시설이다!", this.selectedParkFacilities);
       } catch (error) {
         console.error("시설 목록 가져오기 실패:", error);
       }


### PR DESCRIPTION
## 📢 기능 설명
필요시 실행결과 스크린샷 첨부
![image](https://github.com/user-attachments/assets/3f90b964-ffef-4319-acef-e7866285ec88)
- 테마파크 목록 페이지 불러오기 (재수정)
- 시설 더보기 버튼 클릭 시 시설 정보 안나오는거 다시 불러오기 (재수정)
<br>

## 연결된 issue
연결된 Issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #46 
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가?
  - ex) [feat/#21] 회원 로그인 기능부분 구현
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가? 